### PR TITLE
Fixed unusable sort orders. #16

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -139,6 +139,7 @@ function App() {
         },
         {
             field: 'download',
+            sortable: false,
             headerName: <Typography
                 variant="h5">{doI18n("pages:core-remote-resources:row_download", i18nRef.current)}</Typography>,
             flex: 0.5,

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -124,7 +124,6 @@ function App() {
             field: 'description',
             headerName: <Typography
                 variant="h5">{doI18n("pages:core-remote-resources:row_description", i18nRef.current)}</Typography>,
-            type: "number",
             flex: 2,
             headerAlign: 'left',
             align: 'left'


### PR DESCRIPTION
This PR addresses issue #16 

Disabled the sorting for the Download column since it doesn't make sense to sort the same icon, and fixed the sorting for the Description column:

![chrome_i5j2ocIyH5](https://github.com/user-attachments/assets/a0bbc74c-43d6-40c6-80a6-472d962637f1)
