### PR TITLE
English Human Readable ISO 639-1 Codes

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,6 +14,7 @@ function App() {
     const {typographyRef} = useContext(typographyContext);
     const {i18nRef} = useContext(i18nContext);
     const {debugRef} = useContext(debugContext);
+    const [languageLookup, setLanguageLookup] = useState([]);
 
     const isGraphite = GraphiteTest()
     /** adjSelectedFontClass reshapes selectedFontClass if Graphite is absent. */
@@ -60,6 +61,12 @@ function App() {
         },
         [remoteSource]
     );
+
+    useEffect(() => {
+      fetch('/app-resources/lookups/languages.json') // ISO_639-1 plus grc
+        .then(r => r.json())
+        .then(data => setLanguageLookup(data));
+    }, []);
 
     useEffect(() => {
         if (!isDownloading && (catalog.length > 0) && localRepos) {
@@ -189,7 +196,8 @@ function App() {
                 resourceCode: ce.abbreviation.toUpperCase(),
                 description:ce.description,
                 source:ce.source,
-                language: ce.language_code,
+                language: languageLookup.find(x => x?.id === ce.language_code)?.en ??
+                          ce.language_code,
                 type: doI18n(`flavors:names:${ce.flavor_type}/${ce.flavor}`, i18nRef.current)
             }
         })


### PR DESCRIPTION
This applies the english language name for two-letter ISO 639-1 from the lookup json that we added fairly recently to resource-core. It leave 3-digit codes displayed as 3-digit codes (see the last screenshot below - Aquifer) and only applies the name to the 2-digit codes (see the first two screenshots below -- Xenizo and uW).

<img width="962" height="644" alt="image" src="https://github.com/user-attachments/assets/22d08752-d2f8-4860-a2e6-ca3663cefb6a" />

<img width="958" height="640" alt="image" src="https://github.com/user-attachments/assets/df373f61-6bc1-48ef-814d-4d814f18131d" />

<img width="952" height="647" alt="image" src="https://github.com/user-attachments/assets/543f5644-9b68-4618-a109-f582b5b697db" />
